### PR TITLE
Class Aliases

### DIFF
--- a/iris_doc/language_specification.py
+++ b/iris_doc/language_specification.py
@@ -147,7 +147,6 @@ class LanguageSpecificationModule:
                     newName1 = parentElement['name'].lower()
                 else:
                     newName1 = element['name'].lower()
-
                 if self.__config.isCallback2api and newType == "callback":
                     newType = "api"
 
@@ -173,7 +172,9 @@ class LanguageSpecificationModule:
 
             element['id'] = new_id
 
-            if element['id'] in self.__commentSources:
+            # Check if next id already exists
+            # If it does exist, check if the saved value is set to is_hide, if it's not, then ignore the new value.
+            if element['id'] in self.__commentSources and not self.__commentSources[element['id']].is_hide:
                 continue
 
             finalCommentSource: CommentSource = CommentSource.from_json(

--- a/iris_doc/test/language_specification_test.py
+++ b/iris_doc/test/language_specification_test.py
@@ -70,6 +70,79 @@ class TestLanguageSpecificationModule(unittest.TestCase):
         self.assertIn("class_rtcengineeventhandler", commentSources.keys())
         self.assertIn("class_rtcenginecontext", commentSources.keys())
 
+    def testMatchAliases(self):
+        path = "testMatchTagPatternV2.json"
+        self.__fileSystem.create(path, wipe=True)
+        file = self.__fileSystem.open(path, mode="w")
+        file.write("""
+[
+    {
+        "id": "class_aliashandler",
+        "name": "RtcEngineEventHandler",
+        "description": "Alias interface",
+        "parameters": [],
+        "returns": "",
+        "is_hide": true
+    },
+    {
+        "id": "class_irtcengineeventhandler",
+        "name": "RtcEngineEventHandler",
+        "description": "The SDK uses the RtcEngineEventHandler interface",
+        "parameters": [],
+        "returns": "",
+        "is_hide": false
+    },
+    {
+        "id": "class_anotheraliashandler",
+        "name": "RtcEngineEventHandler",
+        "description": "Alias interface 2",
+        "parameters": [],
+        "returns": "",
+        "is_hide": true
+    },
+    {
+        "id": "callback_aliashandler_onfirstremotevideoframe",
+        "name": "onFirstRemoteVideoFrame",
+        "description": "Occurs when the renderer receives the first frame of the remote video.",
+        "parameters": [
+        ],
+        "returns": "",
+        "is_hide": false
+    },
+    {
+        "id": "class_rtcengineconfig_ng",
+        "name": "RtcEngineContext",
+        "description": "Definition of RtcEngineContext.",
+        "parameters": [
+        ],
+        "returns": "",
+        "is_hide": false
+    }
+]
+        """)
+        file.flush()
+        file.close()
+
+        languageSpecificationConfig: LanguageSpecificationConfig = LanguageSpecificationConfig(
+            isCallback2class=True,
+            isCallback2api=False,
+            idPatternV2=True)
+
+        module = LanguageSpecificationModule(
+            self.__fileSystem, languageSpecificationConfig)
+        module.addTemplateFilePath(path)
+        module.deserialize()
+
+        commentSources = module.getAllCommentSources()
+
+        self.assertEqual(len(commentSources.keys()), 3)
+        self.assertIn("class_rtcengineeventhandler_onfirstremotevideoframe", commentSources.keys())
+        self.assertIn("class_rtcengineeventhandler", commentSources.keys())
+        self.assertIn("class_rtcenginecontext", commentSources.keys())
+        self.assertEqual(
+            commentSources['class_rtcengineeventhandler'].description, "The SDK uses the RtcEngineEventHandler interface"
+        )
+
     def testMultipleTemplateFile(self):
         path = "testMultipleTemplateFile1.json"
         self.__fileSystem.create(path, wipe=True)


### PR DESCRIPTION
With iOS, macOS and Java, sometimes the C++ classes are not exposed, and instead the functions are directly on the main interface. For example, IMediaEngine doesn't exist, and instead all its functions are in IRtcEngine.

So the IMediaEngine and IRtcEngine both use the keyword AgoraRtcEngineKit in the ditamap, but the media engine also has the hide prop. This means when the json parser comes in, it will replace things like "api_imediaengine_setexternalvideosource" with "api_agorartcenginekit_setexternalvideosource" on iOS.
As Flutter already has a unique class of IMediaEngine in the ditamap, it will not cause any changes there.

A test has been added to language_specification_test.py to catch aliases.