### PR TITLE
fix PyYAML setuptool issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 fs~=2.4.16
-pyyaml~=5.1
+pyyaml==6.0.1
 requests~=2.27.1


### PR DESCRIPTION
Fix the ci failed due to the setuptool issue of the  PyYAML https://github.com/littleGnAl/hoe/actions/runs/5665072525/job/15349301243

Pin PyYAML to `6.0.1` should fix the issue
Relative: https://github.com/yaml/pyyaml/issues/723 