### PR TITLE
[PostPhaseDart] Use dart format command

### DIFF
--- a/iris_doc/dart/post_phase_dart.py
+++ b/iris_doc/dart/post_phase_dart.py
@@ -11,5 +11,5 @@ class PostPhaseDart(PostPhase):
         self.__executePath = executePath
 
     def run(self) -> Any:
-        p = subprocess.Popen(["flutter", "format", "."], cwd=self.__executePath)
+        p = subprocess.Popen(["dart", "format", "."], cwd=self.__executePath)
         p.wait()


### PR DESCRIPTION
Deprecated the `flutter format`.
```
The "format" command is deprecated. Please use the "dart format" sub-command instead, which has the same command-line usage as "flutter format".
```